### PR TITLE
Integrate Dan's changes

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -3855,6 +3855,14 @@ public:
     RecordDeclBits.ParamDestroyedInCallee = V;
   }
 
+  bool isRandomized() const {
+    return RecordDeclBits.IsRandomized;
+  }
+
+  void setIsRandomized(bool V) {
+    RecordDeclBits.IsRandomized = V;
+  }
+
   /// Determines whether this declaration represents the
   /// injected class name.
   ///

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -2661,6 +2661,7 @@ class FieldDecl : public DeclaratorDecl, public Mergeable<FieldDecl> {
   unsigned BitField : 1;
   unsigned Mutable : 1;
   mutable unsigned CachedFieldIndex : 30;
+  mutable unsigned OriginalFieldIndex : 30;
 
   /// The kinds of value we can store in InitializerOrBitWidth.
   ///
@@ -2710,6 +2711,7 @@ protected:
             InClassInitStyle InitStyle)
     : DeclaratorDecl(DK, DC, IdLoc, Id, T, TInfo, StartLoc),
       BitField(false), Mutable(Mutable), CachedFieldIndex(0),
+      OriginalFieldIndex(0),
       InitStorage(nullptr, (InitStorageKind) InitStyle) {
     if (BW)
       setBitWidth(BW);
@@ -2730,6 +2732,13 @@ public:
   /// Returns the index of this field within its record,
   /// as appropriate for passing to ASTRecordLayout::getFieldOffset.
   unsigned getFieldIndex() const;
+
+  /// For struct field reorg, this is the original index, 1-based, or
+  /// 0 if reorg did not happen.
+  unsigned getOriginalFieldIndex() const;
+
+  /// For struct field reorg, sets a 1-based index.
+  void setOriginalFieldIndex(unsigned index);
 
   /// Determines whether this field is mutable (C++ only).
   bool isMutable() const { return Mutable; }

--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -1454,10 +1454,13 @@ class DeclContext {
 
     /// Represents the way this type is passed to a function.
     uint64_t ArgPassingRestrictions : 2;
+
+    /// Indicates whether this struct has had its field layout randomized.
+    uint64_t IsRandomized : 1;
   };
 
   /// Number of non-inherited bits in RecordDeclBitfields.
-  enum { NumRecordDeclBits = 14 };
+  enum { NumRecordDeclBits = 15 };
 
   /// Stores the bits used by OMPDeclareReductionDecl.
   /// If modified NumOMPDeclareReductionDeclBits and the accessor

--- a/clang/include/clang/AST/Randstruct.h
+++ b/clang/include/clang/AST/Randstruct.h
@@ -14,12 +14,16 @@
 #ifndef CLANG_INCLUDE_AST_RANDSTRUCT_H_
 #define CLANG_INCLUDE_AST_RANDSTRUCT_H_
 
+#include <string>
+
 namespace clang {
 
 class ASTContext;
 class RecordDecl;
 
 namespace randstruct {
+
+extern std::string SEED;
 
 bool shouldRandomize(const ASTContext &Context, const RecordDecl *RD);
 void randomizeStructureLayout(const ASTContext &Context, const RecordDecl *RD);

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -111,6 +111,8 @@ def err_drv_argument_only_allowed_with : Error<
   "invalid argument '%0' only allowed with '%1'">;
 def err_drv_argument_not_allowed_with : Error<
   "invalid argument '%0' not allowed with '%1'">;
+def err_drv_cannot_open_randstruct_seed_filename : Error<
+  "filename '%0'">;
 def err_drv_invalid_version_number : Error<
   "invalid version number in '%0'">;
 def err_drv_no_linker_llvm_support : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10104,4 +10104,7 @@ def err_bit_cast_non_trivially_copyable : Error<
   "__builtin_bit_cast %select{source|destination}0 type must be trivially copyable">;
 def err_bit_cast_type_size_mismatch : Error<
   "__builtin_bit_cast source size does not equal destination size (%0 vs %1)">;
+
+def cast_from_randomized_struct: Error<
+  "pointer to struct declared with 'randomize_layout' is being cast" "">;
 } // end of sema component.

--- a/clang/include/clang/Driver/CC1Options.td
+++ b/clang/include/clang/Driver/CC1Options.td
@@ -451,6 +451,8 @@ def fcaret_diagnostics_max_lines :
   HelpText<"Set the maximum number of source lines to show in a caret diagnostic">;
 def fmessage_length : Separate<["-"], "fmessage-length">, MetaVarName<"<N>">,
   HelpText<"Format message diagnostics so that they fit within N columns or fewer, when possible.">;
+def randstruct_seed : Separate<["-"], "randstruct-seed">, MetaVarName<"<N>">,
+  HelpText<"Randomization seed for random struct layouts">;
 def randstruct_seed_filename : Separate<["-"], "randstruct-seed-filename">,
   HelpText<"Optional file containing randomization seed for random struct layouts">;
 def verify_EQ : CommaJoined<["-"], "verify=">,

--- a/clang/include/clang/Driver/CC1Options.td
+++ b/clang/include/clang/Driver/CC1Options.td
@@ -451,6 +451,8 @@ def fcaret_diagnostics_max_lines :
   HelpText<"Set the maximum number of source lines to show in a caret diagnostic">;
 def fmessage_length : Separate<["-"], "fmessage-length">, MetaVarName<"<N>">,
   HelpText<"Format message diagnostics so that they fit within N columns or fewer, when possible.">;
+def randstruct_seed_filename : Separate<["-"], "randstruct-seed-filename">,
+  HelpText<"Optional file containing randomization seed for random struct layouts">;
 def verify_EQ : CommaJoined<["-"], "verify=">,
   MetaVarName<"<prefixes>">,
   HelpText<"Verify diagnostic output using comment directives that start with"

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1330,6 +1330,7 @@ def fmacro_backtrace_limit_EQ : Joined<["-"], "fmacro-backtrace-limit=">,
 def fmerge_all_constants : Flag<["-"], "fmerge-all-constants">, Group<f_Group>,
   Flags<[CC1Option, CoreOption]>, HelpText<"Allow merging of constants">;
 def fmessage_length_EQ : Joined<["-"], "fmessage-length=">, Group<f_Group>;
+def randstruct_seed_filename_EQ : Joined<["-"], "randstruct-seed-filename=">, Group<f_Group>;
 def fms_extensions : Flag<["-"], "fms-extensions">, Group<f_Group>, Flags<[CC1Option, CoreOption]>,
   HelpText<"Accept some non-standard constructs supported by the Microsoft compiler">;
 def fms_compatibility : Flag<["-"], "fms-compatibility">, Group<f_Group>, Flags<[CC1Option, CoreOption]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1330,6 +1330,7 @@ def fmacro_backtrace_limit_EQ : Joined<["-"], "fmacro-backtrace-limit=">,
 def fmerge_all_constants : Flag<["-"], "fmerge-all-constants">, Group<f_Group>,
   Flags<[CC1Option, CoreOption]>, HelpText<"Allow merging of constants">;
 def fmessage_length_EQ : Joined<["-"], "fmessage-length=">, Group<f_Group>;
+def randstruct_seed_EQ : Joined<["-"], "randstruct-seed=">, Group<f_Group>;
 def randstruct_seed_filename_EQ : Joined<["-"], "randstruct-seed-filename=">, Group<f_Group>;
 def fms_extensions : Flag<["-"], "fms-extensions">, Group<f_Group>, Flags<[CC1Option, CoreOption]>,
   HelpText<"Accept some non-standard constructs supported by the Microsoft compiler">;

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4312,6 +4312,7 @@ RecordDecl::RecordDecl(Kind DK, TagKind TK, const ASTContext &C,
   setHasNonTrivialToPrimitiveCopyCUnion(false);
   setParamDestroyedInCallee(false);
   setArgPassingRestrictions(APK_CanPassInRegs);
+  setIsRandomized(false);
 }
 
 RecordDecl *RecordDecl::Create(const ASTContext &C, TagKind TK, DeclContext *DC,

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4012,6 +4012,15 @@ unsigned FieldDecl::getFieldIndex() const {
   return CachedFieldIndex - 1;
 }
 
+unsigned FieldDecl::getOriginalFieldIndex() const {
+  return OriginalFieldIndex;
+}
+
+void FieldDecl::setOriginalFieldIndex(unsigned index) {
+  assert(index >= 1);
+  OriginalFieldIndex = index;
+}
+
 SourceRange FieldDecl::getSourceRange() const {
   const Expr *FinalExpr = getInClassInitializer();
   if (!FinalExpr)

--- a/clang/lib/AST/Randstruct.cpp
+++ b/clang/lib/AST/Randstruct.cpp
@@ -210,12 +210,16 @@ void randomizeStructureLayout(const ASTContext &Context, const RecordDecl *RD) {
   SmallVector<Decl *, SMALL_VEC_SIZE> Others;
   SmallVector<FieldDecl *, SMALL_VEC_SIZE> Fields;
   FieldDecl *VLA = nullptr;
+  auto index = 1u;
 
   std::set<Decl *> MutateGuard;
   for (auto *Decl : RD->decls()) {
     MutateGuard.insert(Decl);
     if (isa<FieldDecl>(Decl)) {
       auto *Field = cast<FieldDecl>(Decl);
+      Field->setOriginalFieldIndex(index);
+      ++index;
+
       if (Field->getType()->isIncompleteArrayType()) {
         VLA = Field;
       } else {

--- a/clang/lib/AST/Randstruct.cpp
+++ b/clang/lib/AST/Randstruct.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <random>
+#include <sstream>
 #include <string>
 
 namespace clang {
@@ -225,8 +226,11 @@ void randomizeStructureLayout(const ASTContext &Context, const RecordDecl *RD) {
     }
   }
 
-  std::seed_seq seed(SEED.begin(), SEED.end());
-  std::mt19937 Rng(seed);
+  std::stringstream ss(SEED);
+  ss << ":" << RD->getNameAsString();
+  std::string seed = ss.str();
+  std::seed_seq sseq(seed.begin(), seed.end());
+  std::mt19937 Rng(sseq);
   Randstruct Rand;
   Rand.randomize(Context, Fields, Rng);
 

--- a/clang/lib/AST/Randstruct.cpp
+++ b/clang/lib/AST/Randstruct.cpp
@@ -253,7 +253,8 @@ void randomizeStructureLayout(const ASTContext &Context, const RecordDecl *RD) {
   assert(MutateGuard.size() == NewOrder.size() &&
           "Decl count has been altered after Randstruct randomization!");
   Rand.commit(RD, NewOrder);
-  RD->setIsRandomized(true);
+  // FIXME: Oof, const_cast
+  const_cast<RecordDecl*>(RD)->setIsRandomized(true);
 }
 
 } // namespace randstruct

--- a/clang/lib/AST/Randstruct.cpp
+++ b/clang/lib/AST/Randstruct.cpp
@@ -253,6 +253,7 @@ void randomizeStructureLayout(const ASTContext &Context, const RecordDecl *RD) {
   assert(MutateGuard.size() == NewOrder.size() &&
           "Decl count has been altered after Randstruct randomization!");
   Rand.commit(RD, NewOrder);
+  RD->setIsRandomized(true);
 }
 
 } // namespace randstruct

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3041,7 +3041,6 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
   const ASTRecordLayout *Entry = ASTRecordLayouts[D];
   if (Entry) return *Entry;
 
-
   if (randstruct::shouldRandomize(*this, D)) {
       randstruct::randomizeStructureLayout(*this, D);
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4566,6 +4566,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(Twine(N)));
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_randstruct_seed_EQ)) {
+    CmdArgs.push_back( "-randstruct-seed" );
+    CmdArgs.push_back(A->getValue(0));
+  }
+
   if (Arg *A = Args.getLastArg(options::OPT_randstruct_seed_filename_EQ)) {
     CmdArgs.push_back( "-randstruct-seed-filename" );
     CmdArgs.push_back(A->getValue(0));

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4566,6 +4566,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(Twine(N)));
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_randstruct_seed_filename_EQ)) {
+    CmdArgs.push_back( "-randstruct-seed-filename" );
+    CmdArgs.push_back(A->getValue(0));
+  }
+
   // -fvisibility= and -fvisibility-ms-compat are of a piece.
   if (const Arg *A = Args.getLastArg(options::OPT_fvisibility_EQ,
                                      options::OPT_fvisibility_ms_compat)) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/Frontend/CompilerInvocation.h"
 #include "TestModuleFileExtension.h"
+#include "clang/AST/Randstruct.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/CodeGenOptions.h"
@@ -90,6 +91,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <fstream>
 
 using namespace clang;
 using namespace driver;
@@ -1819,6 +1821,15 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.Plugins.emplace_back(A->getValue(0));
     Opts.ProgramAction = frontend::PluginAction;
     Opts.ActionName = A->getValue();
+  }
+  if (const Arg* A = Args.getLastArg(OPT_randstruct_seed_filename)) {
+    std::string seed_filename = A->getValue(0);
+    std::ifstream seed_file(seed_filename.c_str());
+    if (!seed_file.is_open()) {
+	Diags.Report(diag::err_drv_cannot_open_randstruct_seed_filename)
+	    << A->getValue(0);
+    }
+    std::getline(seed_file, randstruct::SEED);
   }
   Opts.AddPluginActions = Args.getAllArgValues(OPT_add_plugin);
   for (const auto *AA : Args.filtered(OPT_plugin_arg))

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1822,6 +1822,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.ProgramAction = frontend::PluginAction;
     Opts.ActionName = A->getValue();
   }
+
   if (const Arg* A = Args.getLastArg(OPT_randstruct_seed_filename)) {
     std::string seed_filename = A->getValue(0);
     std::ifstream seed_file(seed_filename.c_str());
@@ -1831,6 +1832,11 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
     std::getline(seed_file, randstruct::SEED);
   }
+
+  if (const Arg* A = Args.getLastArg(OPT_randstruct_seed)) {
+      randstruct::SEED = A->getValue(0);
+  }
+
   Opts.AddPluginActions = Args.getAllArgValues(OPT_add_plugin);
   for (const auto *AA : Args.filtered(OPT_plugin_arg))
     Opts.PluginArgs[AA->getValue(0)].emplace_back(AA->getValue(1));

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -1996,14 +1996,11 @@ public:
 	  auto ICE_R = ICE_PT->getAsRecordDecl();
 
 	  if (E_R != nullptr && ICE_R != nullptr && E_R != ICE_R) {
-	    for (auto d : ICE_R->decls()) {
-	      auto f = dyn_cast<FieldDecl>(d);
-	      if (f != nullptr && f->getOriginalFieldIndex() != 0) {
-		// The struct we are casting the pointer from was randomized.
-		S.Context.getDiagnostics().Report(
-		    E->getExprLoc(), diag::cast_from_randomized_struct);
-	        break;
-	      }
+	    if (ICE_R->isRandomized()) {
+	      // The struct we are casting the pointer from was randomized.
+	      S.Context.getDiagnostics().Report(E->getExprLoc(),
+			      diag::cast_from_randomized_struct);
+	      break;
 	    }
 	  }
 	}

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2311,6 +2311,7 @@ AnalysisBasedWarnings::IssueWarnings(sema::AnalysisBasedWarnings::Policy P,
     }
   }
 
+  // FIXME: Any way to get a handle to a RecordDecl struct here?
   clang::randstruct::casts::checkForBadCasts(S, AC);
 }
 

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -19,6 +19,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/ParentMap.h"
+#include "clang/AST/Randstruct.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtCXX.h"
 #include "clang/AST/StmtObjC.h"
@@ -1968,6 +1969,65 @@ public:
 } // namespace clang
 
 //===----------------------------------------------------------------------===//
+// Checking for bad casts from randomize structs
+//===----------------------------------------------------------------------===//
+namespace clang {
+namespace randstruct {
+namespace casts {
+
+class BadCastsASTWalk: public RecursiveASTVisitor<BadCastsASTWalk> {
+  Sema &S;
+public:
+  BadCastsASTWalk(Sema &S) : S(S) {};
+
+  bool VisitCastExpr(const CastExpr *E) {
+    switch (E->getCastKind()) {
+    case CK_BitCast: {
+      const Expr *SubExpr = E->getSubExpr();
+      auto ICE = dyn_cast<ImplicitCastExpr>(SubExpr);
+      if (ICE != nullptr) {
+	CanQualType E_T = S.Context.getCanonicalType(E->getType());
+	CanQualType ICE_T = S.Context.getCanonicalType(ICE->getType());
+	if (isa<PointerType>(E_T) && isa<PointerType>(ICE_T)) {
+	  auto E_SP = ((QualType)E_T)->getPointeeType();
+	  auto ICE_PT = ((QualType)ICE_T)->getPointeeType();
+
+	  auto E_R = E_SP->getAsRecordDecl();
+	  auto ICE_R = ICE_PT->getAsRecordDecl();
+
+	  if (E_R != nullptr && ICE_R != nullptr && E_R != ICE_R) {
+	    for (auto d : ICE_R->decls()) {
+	      auto f = dyn_cast<FieldDecl>(d);
+	      if (f != nullptr && f->getOriginalFieldIndex() != 0) {
+		// The struct we are casting the pointer from was randomized.
+		S.Context.getDiagnostics().Report(
+		    E->getExprLoc(), diag::cast_from_randomized_struct);
+	        break;
+	      }
+	    }
+	  }
+	}
+      }
+      break;
+    }
+    default:
+      break;
+    }
+
+    return true;
+  }
+};
+
+void checkForBadCasts(Sema &S, AnalysisDeclContext &AC)
+{
+  BadCastsASTWalk walker(S);
+  walker.TraverseStmt(AC.getBody());
+}
+}
+}
+}
+
+//===----------------------------------------------------------------------===//
 // AnalysisBasedWarnings - Worker object used by Sema to execute analysis-based
 //  warnings on a function, method, or block.
 //===----------------------------------------------------------------------===//
@@ -2253,6 +2313,8 @@ AnalysisBasedWarnings::IssueWarnings(sema::AnalysisBasedWarnings::Policy P,
       ++NumFunctionsWithBadCFGs;
     }
   }
+
+  clang::randstruct::casts::checkForBadCasts(S, AC);
 }
 
 void clang::sema::AnalysisBasedWarnings::PrintStats() const {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16872,6 +16872,8 @@ void Sema::ActOnFields(Scope *S, SourceLocation RecLoc, Decl *EnclosingDecl,
       CDecl->setIvarRBraceLoc(RBrac);
     }
   }
+
+  Context.getASTRecordLayout(Record);
 }
 
 /// Determine whether the given integral value is representable within


### PR DESCRIPTION
From here: https://github.com/da-x/llvm-project/commits/clang-r365631c-randstruct

This is a ~~first~~ now second draft at merging in Dan's changes with the newer Randstruct code. I left notes on what I changed around to merge it in when I was cherry-picking commits.

Closes #1 
Closes #2 

v1 -> v2:

- [x] Only exclude last field from randomization if and only if it is a variable-length array, or an array of length 0 or 1.
- [x] Command-line seed should have higher priority than filename seed
- [x] Fixup bad cast for randomized struct by confirming it's randomized (previously changing the condition to `!= 0` but now instead just checking a flag.
- [ ] Optimization: don't check for bad casts if the struct has not been randomized